### PR TITLE
Move Range, Scale and TicLabels into the axis module.

### DIFF
--- a/src/axis/mod.rs
+++ b/src/axis/mod.rs
@@ -7,7 +7,7 @@ use std::borrow::Cow;
 use std::iter::IntoIterator;
 
 use traits::Data;
-use {Default, Display, Range, Scale, Script, TicLabels};
+use {Default, Display, Script};
 
 /// A coordinate axis
 #[derive(Clone, Copy)]
@@ -22,16 +22,6 @@ pub enum Axis {
     TopX,
 }
 
-/// A pair of axes that define a coordinate system.
-#[allow(missing_docs)]
-#[derive(Clone, Copy)]
-pub enum Axes {
-    BottomXLeftY,
-    BottomXRightY,
-    TopXLeftY,
-    TopXRightY,
-}
-
 impl Axis {
     pub(crate) fn next(self) -> Option<Axis> {
         use Axis::*;
@@ -43,6 +33,49 @@ impl Axis {
             TopX => None,
         }
     }
+}
+
+/// A pair of axes that define a coordinate system.
+#[allow(missing_docs)]
+#[derive(Clone, Copy)]
+pub enum Axes {
+    BottomXLeftY,
+    BottomXRightY,
+    TopXLeftY,
+    TopXRightY,
+}
+
+/// Axis range
+///
+/// Used by [`AxisProperties::range`].
+///
+/// [`AxisProperties::range`]: struct.AxisProperties.html#method.range
+#[derive(Clone, Copy)]
+pub enum Range {
+    /// Autoscale the axis
+    Auto,
+    /// Set the limits of the axis
+    Limits(f64, f64),
+}
+
+/// Axis scale.
+///
+/// Used by [`AxisProperties::scale`].
+///
+/// [`AxisProperties::scale`]: struct.AxisProperties.html#method.scale
+#[allow(missing_docs)]
+#[derive(Clone, Copy)]
+pub enum Scale {
+    Linear,
+    Logarithmic,
+}
+
+/// Labels attached to the tics of an axis
+pub struct TicLabels<P, L> {
+    /// Labels to attach to the tics
+    pub labels: L,
+    /// Position of the tics on the axis
+    pub positions: P,
 }
 
 /// Properties of the coordinate axes.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -692,23 +692,6 @@ impl Default for Figure {
     }
 }
 
-/// Axis range
-#[derive(Clone, Copy)]
-pub enum Range {
-    /// Autoscale the axis
-    Auto,
-    /// Set the limits of the axis
-    Limits(f64, f64),
-}
-
-/// Labels attached to the tics of an axis
-pub struct TicLabels<P, L> {
-    /// Labels to attach to the tics
-    pub labels: L,
-    /// Position of the tics on the axis
-    pub positions: P,
-}
-
 /// Color
 #[allow(missing_docs)]
 #[derive(Clone, Copy)]
@@ -755,14 +738,6 @@ pub enum PointType {
     Star,
     Triangle,
     X,
-}
-
-/// Axis scale
-#[allow(missing_docs)]
-#[derive(Clone, Copy)]
-pub enum Scale {
-    Linear,
-    Logarithmic,
 }
 
 /// Output terminal

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,10 +1,10 @@
 //! A collection of the most used traits, structs and enums
 
-pub use axis::{Axes, Axis};
+pub use axis::{Axes, Axis, Range, Scale, TicLabels};
 pub use candlestick::Candlesticks;
 pub use curve::Curve::{Dots, Impulses, Lines, LinesPoints, Points, Steps};
 pub use errorbar::ErrorBar::{XErrorBars, XErrorLines, YErrorBars, YErrorLines};
 pub use filledcurve::FilledCurve;
 pub use key::{Horizontal, Justification, Order, Position, Stacked, Vertical};
 pub use traits::Plot;
-pub use {Color, Figure, LineType, PointType, Range, Scale, Terminal, TicLabels};
+pub use {Color, Figure, LineType, PointType, Terminal};


### PR DESCRIPTION
I missed a few traits only used in the `axis` module while cleaning it up.