### PR TITLE
GitHub Action for continuous integration

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,0 +1,64 @@
+on: [push, pull_request]
+
+name: Continuous integration
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+
+  test:
+    name: Test Suite
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+  fmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - run: rustup component add rustfmt
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - run: rustup component add clippy
+      - uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -D warnings

--- a/src/data.rs
+++ b/src/data.rs
@@ -154,7 +154,7 @@ where
 {
     type Scale = (f64, f64, f64, f64, f64);
 
-    #[cfg_attr(feature = "cargo-clippy", allow(clippy::many_single_char_names))]
+    #[allow(clippy::many_single_char_names)]
     fn append_to(self, buffer: &mut Vec<u8>, scale: (f64, f64, f64, f64, f64)) {
         let (a, b, c, d, e) = self;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -841,7 +841,7 @@ impl ::std::error::Error for VersionError {
         }
     }
 
-    fn cause(&self) -> Option<& dyn(::std::error::Error)> {
+    fn cause(&self) -> Option<&dyn (::std::error::Error)> {
         match self {
             VersionError::Exec(err) => Some(err),
             _ => None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -389,10 +389,10 @@
 #![deny(missing_docs)]
 // This lint has lots of false positives ATM, see
 // https://github.com/Manishearth/rust-clippy/issues/761
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::new_without_default))]
+#![allow(clippy::new_without_default)]
 // False positives with images
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::doc_markdown))]
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::many_single_char_names))]
+#![allow(clippy::doc_markdown)]
+#![allow(clippy::many_single_char_names)]
 
 extern crate byteorder;
 extern crate cast;


### PR DESCRIPTION
According to @Dylan-DPC's comment at issue #16, a GitHub action is added to the repository to check branch and pull request build and quality status. *(I chose this over Azure because it seemed more native to our source control platform)*.

The configuration itself is brought over from the [action-rs repository's quickstart guide](https://github.com/actions-rs/meta/blob/edeebc14493689cee04cb6d941c42c36a86e9d18/recipes/quickstart.md). It has been tested and proven to work on [my own fork](https://github.com/mfep/ploteria/actions/runs/135013425).