### PR TITLE
Switching to Rust Edition 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ authors = [
     ]
 name = "ploteria"
 version = "0.1.0"
+edition = "2018"
 
 description = "Criterion's plotting library"
 repository = "https://github.com/ploteria/ploteria"

--- a/src/axis.rs
+++ b/src/axis.rs
@@ -6,8 +6,8 @@ pub use self::grid::Gridline;
 use std::borrow::Cow;
 use std::iter::IntoIterator;
 
-use traits::Data;
-use {Default, Display, Script};
+use crate::traits::Data;
+use crate::{Default, Display, Script};
 
 /// A coordinate axis
 #[derive(Clone, Copy)]
@@ -24,7 +24,7 @@ pub enum Axis {
 
 impl Axis {
     pub(crate) fn next(self) -> Option<Axis> {
-        use Axis::*;
+        use crate::Axis::*;
 
         match self {
             BottomX => Some(LeftY),
@@ -256,7 +256,7 @@ impl<'a> Script for (Axis, &'a AxisProperties) {
     }
 }
 
-impl ::ScaleFactorTrait for AxisProperties {
+impl crate::ScaleFactorTrait for AxisProperties {
     fn scale_factor(&self) -> f64 {
         self.scale_factor
     }

--- a/src/axis/grid.rs
+++ b/src/axis/grid.rs
@@ -1,6 +1,6 @@
 //! Gridline
 
-use {Axis, Display, Script};
+use crate::{Axis, Display, Script};
 
 /// Gridline properties.
 ///

--- a/src/candlestick.rs
+++ b/src/candlestick.rs
@@ -1,11 +1,12 @@
 //! "Candlestick" plots
 
+use itertools::izip;
 use std::borrow::Cow;
 use std::iter::IntoIterator;
 
-use data::Matrix;
-use traits::{self, Data};
-use {Color, Default, Display, Figure, LineType, Plot, Script};
+use crate::data::Matrix;
+use crate::traits::{self, Data};
+use crate::{Color, Default, Display, Figure, LineType, Plot, Script};
 
 /// Properties common to candlestick plots
 pub struct Properties {
@@ -126,7 +127,7 @@ where
     where
         F: FnOnce(&mut Properties) -> &mut Properties,
     {
-        let (x_factor, y_factor) = ::scale_factor(&self.axes, ::Axes::BottomXLeftY);
+        let (x_factor, y_factor) = crate::scale_factor(&self.axes, crate::Axes::BottomXLeftY);
         let Candlesticks {
             x,
             whisker_min,

--- a/src/curve.rs
+++ b/src/curve.rs
@@ -1,11 +1,12 @@
 //! Simple "curve" like plots
 
+use itertools::izip;
 use std::borrow::Cow;
 use std::iter::IntoIterator;
 
-use data::Matrix;
-use traits::{self, Data};
-use {Axes, Color, CurveDefault, Display, Figure, LineType, Plot, PointType, Script};
+use crate::data::Matrix;
+use crate::traits::{self, Data};
+use crate::{Axes, Color, CurveDefault, Display, Figure, LineType, Plot, PointType, Script};
 
 /// Properties common to simple "curve" like plots
 pub struct Properties {
@@ -245,7 +246,7 @@ where
         configure(&mut props);
 
         let (x_factor, y_factor) =
-            ::scale_factor(&self.axes, props.axes.unwrap_or(::Axes::BottomXLeftY));
+            crate::scale_factor(&self.axes, props.axes.unwrap_or(crate::Axes::BottomXLeftY));
 
         let data = Matrix::new(izip!(x, y), (x_factor, y_factor));
         self.plots.push(Plot::new(data, &props));

--- a/src/data.rs
+++ b/src/data.rs
@@ -5,7 +5,7 @@ use std::mem;
 use byteorder::{LittleEndian, WriteBytesExt};
 use cast::From as _0;
 
-use traits::Data;
+use crate::traits::Data;
 
 macro_rules! impl_data {
     ($($ty:ty),+) => {

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
-use key::{Horizontal, Justification, Order, Stacked, Vertical};
-use {Axes, Axis, Color, Display, LineType, PointType, Terminal};
+use crate::key::{Horizontal, Justification, Order, Stacked, Vertical};
+use crate::{Axes, Axis, Color, Display, LineType, PointType, Terminal};
 
 impl Display<&'static str> for Axis {
     fn display(&self) -> &'static str {

--- a/src/errorbar.rs
+++ b/src/errorbar.rs
@@ -1,11 +1,12 @@
 //! Error bar plots
 
+use itertools::izip;
 use std::borrow::Cow;
 use std::iter::IntoIterator;
 
-use data::Matrix;
-use traits::{self, Data};
-use {Color, Display, ErrorBarDefault, Figure, LineType, Plot, PointType, Script};
+use crate::data::Matrix;
+use crate::traits::{self, Data};
+use crate::{Color, Display, ErrorBarDefault, Figure, LineType, Plot, PointType, Script};
 
 /// Properties common to error bar plots
 pub struct Properties {
@@ -216,7 +217,7 @@ where
     where
         F: FnOnce(&mut Properties) -> &mut Properties,
     {
-        let (x_factor, y_factor) = ::scale_factor(&self.axes, ::Axes::BottomXLeftY);
+        let (x_factor, y_factor) = crate::scale_factor(&self.axes, crate::Axes::BottomXLeftY);
 
         let style = e.style();
         let (x, y, length, height, e_factor) = match e {

--- a/src/filledcurve.rs
+++ b/src/filledcurve.rs
@@ -1,11 +1,12 @@
 //! Filled curve plots
 
+use itertools::izip;
 use std::borrow::Cow;
 use std::iter::IntoIterator;
 
-use data::Matrix;
-use traits::{self, Data};
-use {Axes, Color, Default, Display, Figure, Plot, Script};
+use crate::data::Matrix;
+use crate::traits::{self, Data};
+use crate::{Axes, Color, Default, Display, Figure, Plot, Script};
 
 /// Properties common to filled curve plots
 pub struct Properties {
@@ -128,7 +129,7 @@ where
         configure(&mut props);
 
         let (x_factor, y_factor) =
-            ::scale_factor(&self.axes, props.axes.unwrap_or(::Axes::BottomXLeftY));
+            crate::scale_factor(&self.axes, props.axes.unwrap_or(crate::Axes::BottomXLeftY));
 
         let data = Matrix::new(izip!(x, y1, y2), (x_factor, y_factor, y_factor));
         self.plots.push(Plot::new(data, &props));

--- a/src/key.rs
+++ b/src/key.rs
@@ -2,7 +2,7 @@
 
 use std::borrow::Cow;
 
-use {Default, Display, Script};
+use crate::{Default, Display, Script};
 
 /// Properties of the key.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -394,11 +394,6 @@
 #![allow(clippy::doc_markdown)]
 #![allow(clippy::many_single_char_names)]
 
-extern crate byteorder;
-extern crate cast;
-#[macro_use]
-extern crate itertools;
-
 use std::borrow::Cow;
 use std::fmt;
 use std::fs::File;
@@ -408,7 +403,7 @@ use std::path::Path;
 use std::process::{Child, Command};
 use std::str;
 
-use data::Matrix;
+use crate::data::Matrix;
 
 mod data;
 mod display;
@@ -762,13 +757,13 @@ trait Display<S> {
 /// Curve variant of Default
 trait CurveDefault<S> {
     /// Creates `curve::Properties` with default configuration
-    fn default(S) -> Self;
+    fn default(_: S) -> Self;
 }
 
 /// Error bar variant of Default
 trait ErrorBarDefault<S> {
     /// Creates `errorbar::Properties` with default configuration
-    fn default(S) -> Self;
+    fn default(_: S) -> Self;
 }
 
 /// Structs that can produce gnuplot code
@@ -891,8 +886,8 @@ fn parse_version(version_str: &str) -> Result<Version, Option<ParseIntError>> {
 }
 
 fn scale_factor(map: &map::axis::Map<AxisProperties>, axes: Axes) -> (f64, f64) {
-    use Axes::*;
-    use Axis::*;
+    use crate::Axes::*;
+    use crate::Axis::*;
 
     match axes {
         BottomXLeftY => (

--- a/src/map.rs
+++ b/src/map.rs
@@ -1,7 +1,7 @@
 //! Enum Maps
 
 pub mod axis {
-    use Axis;
+    use crate::Axis;
 
     const LENGTH: usize = 4;
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,10 +1,10 @@
 //! A collection of the most used traits, structs and enums
 
-pub use axis::{Axes, Axis, Range, Scale, TicLabels};
-pub use candlestick::Candlesticks;
-pub use curve::Curve::{Dots, Impulses, Lines, LinesPoints, Points, Steps};
-pub use errorbar::ErrorBar::{XErrorBars, XErrorLines, YErrorBars, YErrorLines};
-pub use filledcurve::FilledCurve;
-pub use key::{Horizontal, Justification, Order, Position, Stacked, Vertical};
-pub use traits::Plot;
-pub use {Color, Figure, LineType, PointType, Terminal};
+pub use crate::axis::{Axes, Axis, Range, Scale, TicLabels};
+pub use crate::candlestick::Candlesticks;
+pub use crate::curve::Curve::{Dots, Impulses, Lines, LinesPoints, Points, Steps};
+pub use crate::errorbar::ErrorBar::{XErrorBars, XErrorLines, YErrorBars, YErrorLines};
+pub use crate::filledcurve::FilledCurve;
+pub use crate::key::{Horizontal, Justification, Order, Position, Stacked, Vertical};
+pub use crate::traits::Plot;
+pub use crate::{Color, Figure, LineType, PointType, Terminal};

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -12,7 +12,7 @@ pub trait Plot<This> {
     type Properties;
 
     /// Plots some `data` with some `configuration`
-    fn plot<F>(&mut self, This, F) -> &mut Self
+    fn plot<F>(&mut self, _: This, _: F) -> &mut Self
     where
         F: FnOnce(&mut Self::Properties) -> &mut Self::Properties;
 }


### PR DESCRIPTION
Let's do this before other refactoring/implementation activities.

- Run `cargo fix --edition`,
- Manually removed `extern crate` directives and fixed the macro import of `itertools`.