### PR TITLE
Adding UTF-8 encoding specification to gnuplot input

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -523,6 +523,8 @@ impl Figure {
     fn script(&self) -> Vec<u8> {
         let mut s = String::new();
 
+        s.push_str("set encoding utf8\n");
+
         s.push_str(&format!("set output '{}'\n", self.output.display()));
 
         if let Some(width) = self.box_width {


### PR DESCRIPTION
As the script is built with Rust `String`s, it is in a valid UTF-8 format. It makes sense to instruct the gnuplot terminal to expect UTF-8 encoding.
Fixes issue #17 .